### PR TITLE
feat: link a post directly to its respective GitHub edit page

### DIFF
--- a/pages/[lang]/[pageID].tsx
+++ b/pages/[lang]/[pageID].tsx
@@ -141,11 +141,13 @@ const Page = (props) => {
                             </div>
                         }
 
-                        <div style={{marginTop: '1rem'}}>
-                            <a href={`https://github.com/aavegotchi/aavegotchi-wiki/edit/main/posts/${router.query.lang}/${router.query.pageID}.md`}>
-                                ✏️ Edit this page
-                            </a>
-                        </div>
+                        { router.query.lang === 'en' &&
+                            <div style={{marginTop: '1rem'}}>
+                                <a href={`https://github.com/aavegotchi/aavegotchi-wiki/edit/main/posts/${router.query.lang}/${router.query.pageID}.md`}>
+                                    ✏️ Edit this page
+                                </a>
+                            </div>
+                        }
 
                         <hr />
                         <ReactMarkdownWithHtml

--- a/pages/[lang]/[pageID].tsx
+++ b/pages/[lang]/[pageID].tsx
@@ -142,7 +142,7 @@ const Page = (props) => {
                         }
 
                         <div style={{marginTop: '1rem'}}>
-                            <a href={`https://github.com/almndbtr/aavegotchi-wiki/edit/main/posts/${router.query.lang}/${router.query.pageID}.md`}>
+                            <a href={`https://github.com/aavegotchi/aavegotchi-wiki/edit/main/posts/${router.query.lang}/${router.query.pageID}.md`}>
                                 ✏️ Edit this page
                             </a>
                         </div>

--- a/pages/[lang]/[pageID].tsx
+++ b/pages/[lang]/[pageID].tsx
@@ -141,6 +141,10 @@ const Page = (props) => {
                             </div>
                         }
 
+                        <a href={`https://github.com/almndbtr/aavegotchi-wiki/edit/main/posts/${router.query.lang}/${router.query.pageID}.md`}>
+                            ✏️ Edit this page
+                        </a>
+
                         <hr />
                         <ReactMarkdownWithHtml
 

--- a/pages/[lang]/[pageID].tsx
+++ b/pages/[lang]/[pageID].tsx
@@ -141,9 +141,11 @@ const Page = (props) => {
                             </div>
                         }
 
-                        <a href={`https://github.com/almndbtr/aavegotchi-wiki/edit/main/posts/${router.query.lang}/${router.query.pageID}.md`}>
-                            ✏️ Edit this page
-                        </a>
+                        <div style={{marginTop: '1rem'}}>
+                            <a href={`https://github.com/almndbtr/aavegotchi-wiki/edit/main/posts/${router.query.lang}/${router.query.pageID}.md`}>
+                                ✏️ Edit this page
+                            </a>
+                        </div>
 
                         <hr />
                         <ReactMarkdownWithHtml

--- a/posts/en/developers.md
+++ b/posts/en/developers.md
@@ -11,7 +11,6 @@ Some requested or needed features:
 
 * 🌃 Daark Mode
 * 📱 Make it more Mobile frenly
-* ✏️ "Edit this Page" button that links directly to the Github edit page
 
 <div style="margin-top:50px;"></div>
 


### PR DESCRIPTION
### Summary

Closes #103. 

Hallo, Aarchiver frens! :wave: 

After consulting the [`Develop this wiki`](https://wiki.aavegotchi.com/en/developers) page, I wanted to contribute a new feature: automatically linking posts directly to their GitHub edit page.  🔗 ✨ 

I know the original request calls for a button, but I opted for a plain link––happy to get any design feedback from the team. 🧑‍🎨 

#### Consulted resources

- 📖 [Docs for the `Edit on GitHub link`](https://github.com/jekyll/github-metadata/blob/master/docs/edit-on-github-link.md)
- 🔬 Poked at the source for other documentation sites, like [reactjs.org's implementation for this](https://github.com/reactjs/reactjs.org/blob/845338012cc1aeff53c0bc9bdad9fbe2562b00d6/src/components/MarkdownPage/MarkdownPage.js#L133-L137)

#### Motion pictures

##### Desktop (Safari)

![desktop-motion-preview](https://user-images.githubusercontent.com/78528185/106994374-7a6db280-6731-11eb-8f02-368d277dfc9f.gif)


##### Mobile (Chrome, mocking an iPhone X)

![mobile-motion-preview](https://user-images.githubusercontent.com/78528185/106994358-72ae0e00-6731-11eb-9ab5-024844257080.gif)
